### PR TITLE
fixes multi line yank pop

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -261,13 +261,12 @@ export class Editor {
     if (!this.validateCuaCommand() || this.killRing.isEmpty()) {
       return;
     }
-
+    const currPos = vscode.window.activeTextEditor.selection.start;
     vscode.window.activeTextEditor.edit((editBuilder) => {
       const topText = this.killRing.top();
-      const currPos = vscode.window.activeTextEditor.selection.start;
-      const textRange = new vscode.Range(currPos, currPos.translate({ characterDelta: topText.length }));
-
       editBuilder.insert(this.getSelection().active, topText);
+    }).then(() => {
+      const textRange = new vscode.Range(currPos, vscode.window.activeTextEditor.selection.end);
       this.killRing.setLastInsertedRange(textRange);
     });
     this.lastKill = null;
@@ -286,17 +285,15 @@ export class Editor {
       return false;
     }
 
+    const oldInsertionPoint = this.killRing.getLastInsertionPoint();
     vscode.window.activeTextEditor.edit((editBuilder) => {
       this.killRing.backward();
       const prevText = this.killRing.top();
-      const oldInsertionPoint = this.killRing.getLastInsertionPoint();
-      const newRange = new vscode.Range(
-        oldInsertionPoint,
-        oldInsertionPoint.translate({ characterDelta: prevText.length })
-      );
-
       editBuilder.replace(this.killRing.getLastRange(), prevText);
-      this.killRing.setLastInsertedRange(newRange);
+    }).then(() => {
+      const textRange = new vscode.Range(oldInsertionPoint, vscode.window.activeTextEditor.selection.end);
+      this.killRing.setLastInsertedRange(textRange);
+      vscode.window.activeTextEditor.selection = new vscode.Selection(textRange.start, textRange.end);
     });
     return true;
   }


### PR DESCRIPTION
I've found that when the previous yank is multiline, yank pop (alt + y) doesn't work. I've made the last inserted range history in the killRing able to support multi line yanks. I've also made the yank pop selected after yank (line 296) - if you don't like this i can remove it for this pull.