### PR TITLE
WIP Save the top of the kill ring to system clipboard and fix kill line logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -512,10 +512,10 @@
                     "description": "kill and yank pop will set the contents of system clipboard to the top of the kill ring"
                 },
                 "emacs.killWholeLine": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": " If the variable kill-whole-line is true, kill at the very beginning of a line kills the entire line including the following newline."
-              }
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, kill at the very beginning of a line kills the entire line including the following newline."
+                }
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-emacs-improved",
     "displayName": "Emacs Keymap Improved",
     "description": "emacs like extension for vscode based on hiro-sun's key-map",
-    "version": "1.0.4",
+    "version": "1.1.1",
     "publisher": "rkwan94",
     "homepage": "https://github.com/rkwan94/vscode-emacs",
     "repository": {
@@ -29,7 +29,8 @@
     ],
     "main": "./out/src/extension",
     "contributes": {
-        "commands": [{
+        "commands": [
+            {
                 "command": "emacs.kill",
                 "title": "Cut the text from cursor to line end and save it in emacs kill ring"
             },
@@ -50,7 +51,8 @@
                 "title": "Toggle cua mode"
             }
         ],
-        "keybindings": [{
+        "keybindings": [
+            {
                 "key": "right",
                 "command": "emacs.cursorRight",
                 "when": "editorTextFocus"
@@ -500,12 +502,26 @@
                 "key": "alt+c",
                 "command": "emacs.capitaliseWord"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "Emacs Keymap Improved",
+            "properties": {
+                "emacs.setClipboardContents": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "kill and yank pop will set the contents of system clipboard to the top of the kill ring"
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
+    },
+    "dependencies": {
+        "clipboardy": "^1.2.3",
+        "@types/clipboardy": "^1.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.48",

--- a/package.json
+++ b/package.json
@@ -510,7 +510,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "kill and yank pop will set the contents of system clipboard to the top of the kill ring"
-                }
+                },
+                "emacs.killWholeLine": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": " If the variable kill-whole-line is true, kill at the very beginning of a line kills the entire line including the following newline."
+              }
             }
         }
     },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -297,7 +297,7 @@ export class Editor {
       this.killRing.backward();
       const prevText = this.killRing.top();
       editBuilder.replace(this.killRing.getLastRange(), prevText);
-      this.saveClipboard(this.killRing.top());
+      this.saveClipboard(prevText);
     }).then(() => {
       const textRange = new vscode.Range(oldInsertionPoint, vscode.window.activeTextEditor.selection.end);
       this.killRing.setLastInsertedRange(textRange);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -104,8 +104,8 @@ export class Editor {
 
     const newText =
       casing === "upper" ? currentSelection.text.toUpperCase() :
-      casing === "lower" ? currentSelection.text.toLowerCase() :
-      currentSelection.text.charAt(0).toUpperCase() + currentSelection.text.slice(1);
+        casing === "lower" ? currentSelection.text.toLowerCase() :
+          currentSelection.text.charAt(0).toUpperCase() + currentSelection.text.slice(1);
 
     vscode.window.activeTextEditor.edit(builder => {
       builder.replace(currentSelection.range, newText);
@@ -186,11 +186,11 @@ export class Editor {
       });
     }
 
-      // const newCursorPos = this.getSelection();
+    // const newCursorPos = this.getSelection();
 
-      // if (activateMarkMode) {
-      //     this.setSelection(startPos.active, newCursorPos.active);
-      // }
+    // if (activateMarkMode) {
+    //     this.setSelection(startPos.active, newCursorPos.active);
+    // }
   }
 
   public goToPrevSexp(): void {
@@ -223,24 +223,29 @@ export class Editor {
 
     Promise.all(promises).then(() => {
       const selection = this.getSelection();
-      const range = new vscode.Range(selection.start, selection.end);
-
-      const isKillRepeated = this.lastKill && range.start.isEqual(this.lastKill);
-
+      let range = new vscode.Range(selection.start, selection.end);
       this.setSelection(range.start, range.start);
+      const isKillRepeated = this.lastKill && range.start.isEqual(this.lastKill);
+      let text = vscode.window.activeTextEditor.document.getText(range);
 
-      if (range.isEmpty) {
-        this.killEndOfLine(isKillRepeated);
-      } else {
-        this.killText(range, isKillRepeated);
+      if (vscode.window.activeTextEditor.selection.active.line !== vscode.window.activeTextEditor.document.lineCount
+          && (
+            range.isEmpty 
+            || vscode.window.activeTextEditor.document.getText(range).trim() === ''
+            || (range.start.character === 0 && vscode.workspace.getConfiguration("emacs").get("killWholeLine"))
+          )
+        ) {
+        // include line ending
+        range = new vscode.Range(selection.start, new vscode.Position(range.end.line + 1, 0));
+        this.setSelection(range.start, range.start);
+        text = vscode.window.activeTextEditor.document.getText(range);
       }
-      this.lastKill = range.start;
-      this.saveClipboard(this.killRing.top());
+      this.killText(range, text, isKillRepeated);
     });
   }
-
-  private saveClipboard(text: string) : void {
-    vscode.workspace.getConfiguration("emacs").get("setClipboardContents") 
+  
+  private saveClipboard(text: string): void {
+    vscode.workspace.getConfiguration("emacs").get("setClipboardContents")
       && clipboardy.write(text);
   }
 
@@ -249,9 +254,9 @@ export class Editor {
     const range = new vscode.Range(selection.start, selection.end);
 
     if (!range.isEmpty) {
-      this.killText(range, false);
+      this.killText(range, undefined, false);
     }
-    this.lastKill = range.start;
+    
   }
 
   public copy(): void {
@@ -328,12 +333,12 @@ export class Editor {
     selection = new vscode.Selection(nextLine, nextLine);
     vscode.window.activeTextEditor.selection = selection;
     for (let line = selection.start.line;
-          line < doc.lineCount - 1  && doc.lineAt(line).range.isEmpty;
-          ++line) {
-        promises.push(vscode.commands.executeCommand("deleteRight"));
+      line < doc.lineCount - 1 && doc.lineAt(line).range.isEmpty;
+      ++line) {
+      promises.push(vscode.commands.executeCommand("deleteRight"));
     }
     Promise.all(promises).then(() => {
-        vscode.window.activeTextEditor.selection = new vscode.Selection(anchor, anchor);
+      vscode.window.activeTextEditor.selection = new vscode.Selection(anchor, anchor);
     });
   }
 
@@ -518,38 +523,22 @@ export class Editor {
     return !currRegion.start.isEqual(currRegion.end);
   }
 
-  private killEndOfLine(killRepeated: boolean): void {
-    const currentCursorPosition = vscode.window.activeTextEditor.selection.active;
-    vscode.commands.executeCommand("emacs.cursorEnd")
-    .then(() => {
-      const newCursorPos = vscode.window.activeTextEditor.selection.active;
-      const rangeTillEnd = new vscode.Range(currentCursorPosition, newCursorPos);
-      if (rangeTillEnd.isEmpty) {
-        vscode.commands.executeCommand("editor.action.deleteLines").then(() => {
-          this.killRing.append("\n");
-        });
-      }
-
-      return vscode.window.activeTextEditor.document.getText(rangeTillEnd);
-    }).then((text: string) => {
-      vscode.window.activeTextEditor.selection.active = currentCursorPosition;
-      vscode.commands.executeCommand("deleteRight").then(() => {
-        killRepeated ? this.killRing.append(text) : this.killRing.save(text);
-      });
-    });
-
-    this.toggleMarkMode();
-  }
-
-  private killText(range: vscode.Range, killRepeated: boolean): void {
-    const text = vscode.window.activeTextEditor.document.getText(range);
+  private killText(range: vscode.Range, text: string, killRepeated: boolean): void {
+    if (range.isEmpty) {
+      return;
+    }
+    if (!text) {
+      text = vscode.window.activeTextEditor.document.getText(range);
+    }
     const promises = [
       this.delete(range),
     ];
 
     Promise.all(promises).then(() => {
+      this.lastKill = range.start;
       this.status.deactivate(Mode.Mark);
       killRepeated ? this.killRing.append(text) : this.killRing.save(text);
+      this.saveClipboard(this.killRing.top());
     });
   }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -240,7 +240,7 @@ export class Editor {
   }
 
   private saveClipboard(text: string) : void {
-    vscode.workspace.getConfiguration("vscode-emacs-improved").get("emacs.setClipboardContents") 
+    vscode.workspace.getConfiguration("emacs").get("setClipboardContents") 
       && clipboardy.write(text);
   }
 
@@ -287,7 +287,7 @@ export class Editor {
     const currentPosition = vscode.window.activeTextEditor.selection.active;
     const lastInsertionRange = this.killRing.getLastRange();
 
-    if (!lastInsertionRange.end.isEqual(currentPosition)) {
+    if (!lastInsertionRange || !lastInsertionRange.end.isEqual(currentPosition)) {
       this.status.setStatusBarMessage("Previous command was not a yank.", 3000);
       return false;
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3,6 +3,7 @@ import KillRing from "./killring";
 import Register from "./registers";
 import * as sexp from "./sexp";
 import StatusIndicator, { Mode } from "./statusIndicator";
+import * as clipboardy from "clipboardy"
 
 export class Editor {
 
@@ -234,7 +235,13 @@ export class Editor {
         this.killText(range, isKillRepeated);
       }
       this.lastKill = range.start;
+      this.saveClipboard(this.killRing.top());
     });
+  }
+
+  private saveClipboard(text: string) : void {
+    vscode.workspace.getConfiguration("vscode-emacs-improved").get("emacs.setClipboardContents") 
+      && clipboardy.write(text);
   }
 
   public killRegion(): void {
@@ -290,6 +297,7 @@ export class Editor {
       this.killRing.backward();
       const prevText = this.killRing.top();
       editBuilder.replace(this.killRing.getLastRange(), prevText);
+      this.saveClipboard(this.killRing.top());
     }).then(() => {
       const textRange = new vscode.Range(oldInsertionPoint, vscode.window.activeTextEditor.selection.end);
       this.killRing.setLastInsertedRange(textRange);


### PR DESCRIPTION
New config item : emacs.setClipboardContents = false

I find this feature useful because I frequently use kill for cut, and I can transfer kill contents to other applications.

I refactored the kill line logic to mimic functionality described for kill-line at https://www.gnu.org/software/emacs/manual/html_node/emacs/Killing-by-Lines.html

New config item : emacs.killWholeLine = false
If true, kill at the very beginning of a line kills the entire line including the following newline.

@rkwan94 I'm looking for feedback on these changes and if you approve I'll update documentation and remove the WIP from this pull request